### PR TITLE
 Section metadata "Wide" for full screen images

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -617,7 +617,7 @@ main > .section {
 }
 
 .section.wide img {
-  width: 100%;;
+  width: 100%;
 }
 
 .section > .default-content-wrapper > p.fragment-wrapper {

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -616,6 +616,10 @@ main > .section {
   padding: 0;
 }
 
+.section.wide img {
+  width: 100%;;
+}
+
 .section > .default-content-wrapper > p.fragment-wrapper {
   margin: 0;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #38 
Test URLs:
- Before: https://main--sling--da-pilot.aem.live/latino-es/service
- After: https://fullscreenimages--sling--da-pilot.aem.live/latino-es/service
