### PR TITLE
double tildes create strikeout for unlinked text too

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -341,13 +341,14 @@ async function setNavType() {
 }
 
 export function replaceTildesWithDel() {
-  const divs = document.querySelectorAll('div, div > p');
-  divs.forEach((div) => {
-    const text = div.innerHTML;
-    const tildeRegex = /^~~(.*?)~~$/;
-    const match = text.match(tildeRegex);
-    if (match) {
-      div.innerHTML = text.replace(tildeRegex, '<del>$1</del>');
+  // Only process block-level elements where tildes might wrap HTML
+  const blocks = document.querySelectorAll('p, li, h1, h2, h3, h4, h5, h6, div');
+  const tildeRegex = /~~([\s\S]*?)~~/g; // [\s\S] allows matching across tags and newlines
+
+  blocks.forEach((block) => {
+    // Only replace if there are tildes present
+    if (block.innerHTML.includes('~~')) {
+      block.innerHTML = block.innerHTML.replace(tildeRegex, '<del>$1</del>');
     }
   });
 }


### PR DESCRIPTION
See the bottom of the test page for before/after use cases of plain text that wasn't rendering as a strikeout until this PR.

Fix #4

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/buttons
- After: https://4-tildedelete--sling--da-pilot.aem.page/drafts/chelms/buttons

![image](https://github.com/user-attachments/assets/327d0740-5526-4014-a03b-777b89bd2984)

