### PR TITLE
Fix header in Da preview new pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -83,10 +83,6 @@
       width: 100%;
     }
 
-    #nav .zipcode-wrapper, #nav .nav-sections, header .section.nav-top {
-      display: none !important;
-    }
-
     header nav#nav[aria-expanded="true"] .nav-brand {
       width: 100%;
     }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #57 

Test URLs:
- Before: https://main--sling--da-pilot.aem.live/drafts/ritwik/ritwik123?martech=off&dapreview=on
- After: https://issue57--sling--da-pilot.aem.live/drafts/ritwik/ritwik123?martech=off&dapreview=on

untill published the DA preview URL like https://main--sling--da-pilot.aem.live/drafts/ritwik/ritwik123?martech=off&dapreview=on returns 404.html which display none the headers. 

hence removing it to fix live DA preview for non published pages.