### PR TITLE
92 - Add image alt text when Dynamic Media provides "title" field text

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -587,15 +587,8 @@ export function decorateExtImage() {
       const picture = document.createElement('picture');
       const img = document.createElement('img');
       img.classList.add('svg');
-
-      // Use the title attribute from Dynamic Media images as alt text if available
-      if (a.title) {
-        img.alt = a.title;
-      } else {
-        // Fallback to a default alt text if title is not available
-        img.alt = 'Sling TV image';
-      }
-
+      // if the link title to an external image was authored, assign as alt text, else use a default
+      img.alt = a.title || 'Sling TV image';
       // making assumption it is not LCP
       img.loading = 'lazy';
       img.src = extImageSrc;

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -587,8 +587,15 @@ export function decorateExtImage() {
       const picture = document.createElement('picture');
       const img = document.createElement('img');
       img.classList.add('svg');
-      // this alt is a cop out, but it's better than nothing
-      img.alt = 'Sling TV image';
+
+      // Use the title attribute from Dynamic Media images as alt text if available
+      if (a.title) {
+        img.alt = a.title;
+      } else {
+        // Fallback to a default alt text if title is not available
+        img.alt = 'Sling TV image';
+      }
+
       // making assumption it is not LCP
       img.loading = 'lazy';
       img.src = extImageSrc;


### PR DESCRIPTION
Updating alt text in images when authored with a "title" value. Fallback to "Sling TV image" alt text if no title is available. 

Fix #92 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/aemedge/fragments/000-buttons
- After: https://92-assetAltText--sling--da-pilot.aem.page/aemedge/fragments/000-buttons

Additional Test URLs (in fragment):
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/fragbutts
- After: https://92-assetAltText--sling--da-pilot.aem.page/drafts/chelms/fragbutts