### PR TITLE
adding error messaging for non dm assets when they added to doc

### DIFF
--- a/tools/aemcs-assetpicker/assets.html
+++ b/tools/aemcs-assetpicker/assets.html
@@ -35,7 +35,7 @@
       Error initializing Asset Selector: <span id="error-message-text"></span>
     </div>
   </template>
-  
+    
   <script type="module" src="assets.js"></script>
 </body>
 </html> 

--- a/tools/aemcs-assetpicker/assets.js
+++ b/tools/aemcs-assetpicker/assets.js
@@ -132,6 +132,7 @@ async function init() {
       repositoryId,
       aemTierType,
       handleSelection: (assets) => {
+        let scene7ErrorShown = false;
         assets.forEach((asset) => {
           if (asset.type === 'folder') {
             return;
@@ -139,7 +140,18 @@ async function init() {
 
           const assetUrl = asset.path || asset.href || asset.downloadUrl || asset.url;
           const scene7Url = asset['repo:dmScene7Url'];
-
+          if (!scene7Url) {
+            if (!scene7ErrorShown) {
+              if (actions?.sendHTML) {
+                actions.sendHTML(`DM url is not available for the asset <b>"${assetUrl}" </b>. Please cross check DM renditions at <a href="https://${repositoryId}/${assetUrl}">${repositoryId}</a> and retry once DM url is available.`);
+              }
+              if (actions?.closeLibrary) {
+                actions.closeLibrary();
+              }
+              scene7ErrorShown = true;
+            }
+            return;
+          }
           if (!assetUrl) {
             return;
           }


### PR DESCRIPTION
**Note:** Please ensure you have selected `da-pilot/sling` as the base repository when creating this pull request.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #111 

Test URLs:
- Before: https://main--sling--da-pilot.aem.live/channels
- After: https://dmpicker--sling--da-pilot.aem.live/channels

To test try to insert the following asset into a document
![image](https://github.com/user-attachments/assets/85380f2e-b07a-4a40-a2e8-6f4296e57e20)

