### PR TITLE
Updating submit button styling

### DIFF
--- a/aemedge/blocks/channel-lookup/channel-lookup.css
+++ b/aemedge/blocks/channel-lookup/channel-lookup.css
@@ -179,7 +179,8 @@
     }
 
     .channel-lookup.block #zipcodebtn:hover {
-        transform: scale(1.1);
+        box-shadow: rgb(7 7 11 / 40%) 0 24px 57px 0;
+        transform: scale(1.05);
     }
 
     .channel-lookup.block .channel-img {

--- a/aemedge/blocks/channel-lookup/channel-lookup.js
+++ b/aemedge/blocks/channel-lookup/channel-lookup.js
@@ -78,7 +78,7 @@ export default async function decorate(block) {
   spanZipInput.append(labelTag);
   const spanBtn = createTag('span');
   const buttonTag = createTag('button', { class: 'submit-button', id: 'zipcodebtn' });
-  buttonTag.innerText = 'SUBMIT';
+  buttonTag.innerText = 'Submit';
   spanBtn.append(buttonTag);
   formContainer.append(spanZipInput, spanBtn);
   block.append(formContainer);


### PR DESCRIPTION
The content of the warning block is defined in the placeholders.json spreadsheet as `localchannelwarning`, it will need to be updated on that spreadsheet to remove the reference to the Olympics as the new default placeholder text warning.  The CSS styling of the button and button text case have been updated to match the live sling.com site, see https://www.sling.com/programming/local-channels?zip-locals=01002 for comparison.

Fix #119 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/aemedge/fragments/000-buttons
- After: https://119-ChannelLookupBlock--sling--da-pilot.aem.page/aemedge/fragments/000-buttons

Button styling (hover):
![image](https://github.com/user-attachments/assets/17a423ad-39b9-4ed3-85e2-70aee9e4c026)
