### PR TITLE
add style variables for table, remove unnecessary code styling

### DIFF
--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -1,9 +1,106 @@
+/* table cell color overrides, same as columns.css */
+.table td {
+  &.bg-primary-light {
+    background: var(--primary-light);
+  }
+
+  &.bg-white {
+    background: var(--clr-white);
+  }
+
+  &.bg-dark-rock-candy {
+    background: var(--dark-rock-candy);
+    color: var(--clr-white);
+  }
+
+  &.bg-dark-tangerine {
+    background-color: var(--dark-tangerine);
+    color: var(--clr-white);
+  }
+
+  &.bg-primary-dark {
+    background: var(--primary-dark);
+    color: var(--clr-white);
+  }
+
+  &.bg-highlight-coal {
+    background: var(--highlight-coal);
+    color: var(--clr-white);
+  }
+
+  &.bg-blueberry {
+    background: var(--blueberry);
+    color: var(--clr-white);
+  }
+
+  &.bg-sling-blue {
+    background: var(--sling-blue);
+    color: var(--clr-white);
+  }
+
+  &.bg-accessible-blue {
+    background: var(--accessible-blue);
+    color: var(--clr-white);
+  }
+
+  &.bg-pearl {
+    background: var(--pearl);
+  }
+
+  &.bg-charcoal {
+    background: var(--charcoal);
+    color: var(--clr-white);
+  }
+
+  &.bg-smoke {
+    background: var(--smoke);
+    color: var(--clr-white);
+  }
+
+  &.bg-black {
+    background: var(--black);
+    color: var(--clr-white);
+  }
+
+  &.bg-cherry-red {
+    background: var(--cherry-red);
+    color: var(--clr-white);
+  }
+
+  &[class^="bg-"] { /* stylelint-disable no-descending-specificity */
+    padding-top: 12px;
+    padding-bottom: 12px;
+      width: calc(100% - 24px);
+      margin-left: auto;
+      margin-right: auto;
+
+     > .button-container {
+       margin-left: 12px;
+       margin-right: 12px;
+     }
+    }
+
+  &.bg-white, &.bg-primary-light, &.bg-mac-and-cheese, &.bg-pearl {
+    h1, h2, h3, h4, h5, h6, p, li {
+      color: inherit;
+    }
+
+    a:not(.button, .blue) {
+      color: var(--link-color);
+    }
+  }
+
+    a:not(.button, .blue, .black, .white) {
+      text-decoration: underline;
+    }
+  }
+
+
 .table {
   width: 100%;
   overflow-x: auto;
-}
 
-.table table {
+table {
   width: 100%;
   max-width: 100%;
   border-collapse: collapse;
@@ -21,8 +118,8 @@
   td:not([data-align="right"], [data-align="justify"], [data-align="justify"]) {
     text-align: center;
   }
+ }
 }
-
 
 /* bordered variant */
 .table.bordered table th,

--- a/aemedge/blocks/table/table.js
+++ b/aemedge/blocks/table/table.js
@@ -28,6 +28,9 @@ export default async function decorate(block) {
     [...child.children].forEach((col) => {
       const cell = buildCell(header ? i : i + 1);
       cell.innerHTML = col.innerHTML;
+      if (col.className) {
+        cell.className = col.className; // to allow cell color overrides
+      }
 
       // Add data attributes if present
       if (col.dataset.align) {

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -253,21 +253,6 @@ pre {
   overflow: scroll;
 }
 
-code {
-  font-family: inherit;
-  color: var(--clr-fire);
-  font-size: inherit;
-  font-weight: bold;
-}
-
-code.spacer2 {
-  line-height: 3em;
-}
-
-code.spacer3 {
-  line-height: 4.5em;
-}
-
 picture {
   text-decoration: unset;
   line-height: 0; /* this and display:block removes extra space */


### PR DESCRIPTION
Just like column cells, table cells can have bg colors.
See the contents of the table in my test URL page for what is available now (blue) and what is a TODO.

Fix #137 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/variables
- After: https://137-tablecolors--sling--da-pilot.aem.page/drafts/chelms/variables
