### PR TITLE
Text size variables added

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -485,13 +485,22 @@ export function extractStyleVariables() {
     const isParagraph = node.tagName === 'P';
     const text = node.textContent;
     const colorRegex = text && /{([a-zA-Z-\s]+)?}/; // color must be letters or dashes
-    const numberRegex = text && /\{(\d{1,2})?}/;
+    const numberRegex = text && /\{(\d{1,2})?}/; // numbers are 2 digits or less (width %)
+    const sizeRegex = text && /\{size-([^}]*)\}/; // size-xl etc.
+
     const spanRegex = new RegExp(`\\[([\\s\\S]*?)\\]${colorRegex.source}`);
 
     const spacerMatch = text.match(/\{spacer-(\d+)}/); // {spacer-5}
     const colorMatches = text.match(colorRegex);
     const numberMatches = text.match(numberRegex);
     const spanMatches = text.match(spanRegex);
+    const sizeMatches = text.match(sizeRegex);
+
+    if (sizeMatches) {
+      const size = sizeMatches[1];
+      node.classList.add(`size-${size}`);
+      node.innerHTML = node.innerHTML.replace(sizeRegex, '');
+    }
 
     if (isParagraph && spacerMatch) {
       const spacerHeight = parseInt(spacerMatch[1], 10);

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -137,6 +137,74 @@ h6 {
   scroll-margin: calc(var(--nav-height) + 1em);
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+li {
+  &.size-huge {
+    font-size:3rem;line-height:3.5rem;font-weight:700
+  }
+
+  &.size-4xl {
+    font-size: 2.5rem;
+    line-height: 3.5rem;
+    font-weight: 700;
+  }
+
+  &.size-3xl {
+    font-size: 2.25rem;
+    line-height: 2.688rem;
+    font-weight: 700;
+  }
+
+  &.size-2xl {
+    font-size: 1.75rem;
+    line-height: 2.125rem;
+    font-weight: 700;
+  }
+
+  &.size-xl {
+    font-size: 1.5rem;
+    line-height: 2.125rem;
+    font-weight: 700;
+  }
+
+  &.size-l {
+    font-size: 1.25rem;
+    line-height: 1.5rem;
+    font-weight: 700;
+  }
+
+  &.size-m {
+    font-size: 1.125rem;
+    line-height: 1.125rem;
+    font-weight: 400;
+  }
+
+  &.size-s {
+    font-size: .875rem;
+    line-height: 1.125rem;
+    font-weight: 300;
+  }
+
+  &.size-xs {
+    font-size: .75rem;
+    line-height: 1.125rem;
+    font-weight: 300;
+  }  
+}
+
+p.size-xs a {
+    font-size: .75rem !important;
+    line-height: 1.125rem !important;
+    font-weight: 500 !important;
+    text-decoration: underline !important;
+  }
+  
 h1 {
   font-size: var(--heading-font-size-xxl)
 }


### PR DESCRIPTION
See the comparison tests at the bottom of the test page
- the variables shall be at the end of an element H1-H6, p, li
- the variables will append to that element's class name 
- styles have been added for class names
- tested with inline links and color styling too
- I will add the variables to our 'color tags' sheet for now

Fix #139 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/variables
- After: https://137-tablecolors--sling--da-pilot.aem.page/drafts/chelms/variables

