### PR TITLE
link targets added

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -552,12 +552,13 @@ export function extractStyleVariables() {
       if (colorMatches && colorMatches[1] !== undefined) {
         anchor.classList.add(`bg-${toClassName(colorMatches[1])}`);
         [anchor.textContent, anchor.title] = [anchor.textContent, anchor.title].map((str) => str.replace(colorMatches[0], ''));
+        anchor.setAttribute('aria-label', anchor.textContent);
       }
       if (targetMatches && targetMatches[1] !== undefined) {
         anchor.setAttribute('target', targetMatches[1]);
         [anchor.textContent, anchor.title] = [anchor.textContent, anchor.title].map((str) => str.replace(targetMatches[0], ''));
+        anchor.setAttribute('aria-label', anchor.textContent);
       }
-      anchor.setAttribute('aria-label', anchor.textContent);
     }
   });
 }


### PR DESCRIPTION
In the "font size testing" section under the table, the last 2 items in each column show the standard link target behavior (left side) vs. when there is a "target" variable applied to the link. The fire button below that also has an override to open sling.com in a new window.

![image](https://github.com/user-attachments/assets/1af64de2-bd28-4431-b908-ca51966da3a7)


Fix #114 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/variables
- After: https://114-linktargets--sling--da-pilot.aem.page/drafts/chelms/variables
