### PR TITLE
135 ids

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -489,7 +489,8 @@ export function extractStyleVariables() {
     const alignRegex = text && /\{align-([^}]*)\}/; // align-right, align-center, align-left
     const valignRegex = text && /\{valign-([^}]*)\}/; // valign-top, valign-middle, valign-bottom
     const targetRegex = text && /\{target-([^}]*)\}/; // target-blank, target-self
-    const colorRegex = text && /\{(?!size-|align-|valign-|spacer-|target-)([a-zA-Z-\s]+)?\}/;
+    const idRegex = text && /\{id-([^}]*)\}/; // id-coolsection, etc
+    const colorRegex = text && /\{(?!size-|align-|valign-|spacer-|target-|id-)([a-zA-Z-\s]+)?\}/;
     const spanRegex = new RegExp(`\\[([\\s\\S]*?)\\]${colorRegex.source}`); // [plain text]{color}
 
     const spacerMatch = text.match(/\{spacer-(\d+)}/); // {spacer-5}
@@ -500,7 +501,7 @@ export function extractStyleVariables() {
     const valignMatches = text.match(valignRegex);
     const colorMatches = text.match(colorRegex);
     const targetMatches = text.match(targetRegex);
-
+    const idMatches = text.match(idRegex);
     // case where size, align are to be added to the node
     if (sizeMatches && sizeMatches[1] !== undefined) {
       const size = sizeMatches[1];
@@ -512,7 +513,14 @@ export function extractStyleVariables() {
       node.classList.add(`align-${align}`);
       node.innerHTML = node.innerHTML.replace(alignRegex, '');
     }
-
+    // case where id is in the P tag, replace the P with an A id=.
+    if (isParagraph && idMatches && idMatches[1] !== undefined) {
+      const id = idMatches[1];
+      const a = document.createElement('a');
+      a.id = id;
+      a.innerHTML = '';
+      node.parentNode.replaceChild(a, node);
+    }
     // case where new spacer node is created
     if (isParagraph && spacerMatch) {
       const spacerHeight = parseInt(spacerMatch[1], 10);

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -516,6 +516,7 @@ export function extractStyleVariables() {
     // case where id is in the P tag, replace the P with an A id=.
     if (isParagraph && idMatches && idMatches[1] !== undefined) {
       const id = idMatches[1];
+      // Create a new <a> element
       const a = document.createElement('a');
       a.id = id;
       a.innerHTML = '';

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -380,6 +380,10 @@ a:any-link {
   text-decoration: none;
 }
 
+a[id] {
+  scroll-margin-top: calc(var(--nav-height) + 1em);
+}
+
 a:hover {
   text-decoration: none;
   color: var(--link-hover-color);


### PR DESCRIPTION
When `{id-something} `is authored as a p tag, it becomes `<a id="something></a>`. Then it can be linked using the hash.

Fix #135 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/buttons#fragment
- After: https://135-ids--sling--da-pilot.aem.page/drafts/chelms/buttons#fragment
