### PR TITLE
Fix extra spacing and box shadow gaps

### DIFF
--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -4,9 +4,6 @@
 
 .carousel .carousel-slides-container {
   position: relative;
-  
-  /* Add a subtle box shadow for depth */
-  box-shadow: 0 4px 8px rgb(0 0 0 / 5%);
   border-radius: 4px;
   overflow: hidden;
 }

--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -116,8 +116,8 @@
   inset: 0; */
   min-width: 90%;
   width: 90%;
-  min-height: 90%;
-  height: 90%;
+  min-height: 100%;
+  height: 100%;
 }
 
 .carousel .carousel-slide .carousel-slide-image picture > img {
@@ -356,6 +356,7 @@
 
 .carousel.full .carousel-slide .carousel-slide-image picture > img {
   width: 100%;
+  height: 100%;
   object-fit: cover;
   margin: 0;
   border-radius: 0;


### PR DESCRIPTION
Fix #168 

Simplified version of carousel page at the *.page URLs, and different banner variants on the *.live page. They all look corrected properly to me. 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/ritwik/carousel
- After: https://168-carousel--sling--da-pilot.aem.page/drafts/ritwik/carousel

Additional Test URLs:
- Before: https://main--sling--da-pilot.aem.live/drafts/ritwik/carousel
- After: https://168-carousel--sling--da-pilot.aem.live/drafts/ritwik/carousel

![SCR-20250530-ocmt](https://github.com/user-attachments/assets/57097b95-d077-4f6e-bdba-5779b6e4d790)
![SCR-20250530-ocsm](https://github.com/user-attachments/assets/481d8df3-a92e-42eb-afdd-df7f3e9d9da2)
