### PR TITLE
Add aspect-ratio selection in authoring for carousel images

### DIFF
--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -106,7 +106,16 @@
   width: 100%;
   min-height: 100%;
   height: 100%;
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 2 / 3; /* default aspect ratio (portrait) for images in carousel */
+}
+
+
+.aspect-square .carousel .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: 1 / 1;
+}
+
+.aspect-landscape .carousel .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: 16 / 9;
 }
 
 .carousel.medium .carousel-slide .carousel-slide-image picture {

--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -118,6 +118,10 @@
   aspect-ratio: 16 / 9;
 }
 
+.aspect-none .carousel .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: unset;
+}
+
 .carousel.medium .carousel-slide .carousel-slide-image picture {
   /* position: absolute;
   inset: 0; */

--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -106,6 +106,7 @@
   width: 100%;
   min-height: 100%;
   height: 100%;
+  aspect-ratio: 2 / 3;
 }
 
 .carousel.medium .carousel-slide .carousel-slide-image picture {

--- a/aemedge/blocks/tabs/tabs.js
+++ b/aemedge/blocks/tabs/tabs.js
@@ -109,19 +109,27 @@ export default async function decorate(block) {
           rows.forEach((row) => {
             const subBlockContent = [];
             const contentKey = row.children[1].innerHTML;
+            console.log('🚀 ~ rows.forEach ~ contentKey:', contentKey);
             const contentValue = row.children[2].innerHTML;
+            console.log('🚀 ~ rows.forEach ~ row.children[2]:', row.children[2]);
+            console.log('🚀 ~ rows.forEach ~ contentValue:', contentValue);
             subBlockContent.push([contentKey, contentValue]);
             // build sub block with the existing content
             const subBlock = buildBlock(subBlockToBuild, subBlockContent);
             // add tabCategory and sub block content to newDiv
             const tabCategoryDiv = document.createElement('div');
             tabCategoryDiv.innerHTML = row.firstElementChild.innerHTML;
+            // const tabAspectRatioDiv = document.createElement('div');
+            // tabAspectRatioDiv.innerHTML = contentValue.firstElementChild;
             const tabContentDiv = document.createElement('div');
             tabContentDiv.append(subBlock);
             const newRow = document.createElement('div');
             newRow.append(tabCategoryDiv);
+            // newRow.append(tabAspectRatioDiv);
             newRow.append(tabContentDiv);
             newBlock.append(newRow);
+            console.log('🚀 ~ rows.forEach ~ newRow:', newRow);
+            // console.log('🚀 ~ rows.forEach ~ tabAspectRatioDiv:', tabAspectRatioDiv);
           });
         }
       }

--- a/aemedge/blocks/tabs/tabs.js
+++ b/aemedge/blocks/tabs/tabs.js
@@ -11,6 +11,31 @@ function hasWrapper(el) {
   return !!el.firstElementChild && window.getComputedStyle(el.firstElementChild).display === 'block';
 }
 
+/**
+ * Finds the first aspect ratio class (e.g., "aspect-square") in the given row's children.
+ * @param {HTMLElement} row - The row element to search.
+ * @returns {string|null} The aspect ratio class name if found, otherwise null.
+ */
+function getAspectRatioClass(row) {
+  // Check for aspect-* class on the second column
+  const aspectClass1 = row.children[1] && row.children[1].classList
+    ? [...row.children[1].classList].find((cls) => cls.startsWith('aspect-'))
+    : null;
+  // Check for aspect-* class on the third column
+  const aspectClass2 = row.children[2] && row.children[2].classList
+    ? [...row.children[2].classList].find((cls) => cls.startsWith('aspect-'))
+    : null;
+  // Check for aspect-* class on a nested div inside the third column
+  let aspectClass3 = null;
+  if (row.children[2]) {
+    const nestedDiv = row.children[2].querySelector('div');
+    if (nestedDiv && nestedDiv.classList) {
+      aspectClass3 = [...nestedDiv.classList].find((cls) => cls.startsWith('aspect-')) || null;
+    }
+  }
+  return aspectClass1 || aspectClass2 || aspectClass3 || null;
+}
+
 export default async function decorate(block) {
   // nonStandard = mix of 2 and 3 column rows for sub blocks under tabs
   // standard = all 3 column rows for sub blocks under tabs
@@ -49,6 +74,12 @@ export default async function decorate(block) {
           tabCategoryDiv.innerHTML = row.firstElementChild.innerHTML;
           const tabContentDiv = document.createElement('div');
           tabContentDiv.append(subBlock);
+          // check if aspect ratio is present and set aspect ratio class
+          const aspectMatches = getAspectRatioClass(row);
+          if (aspectMatches) {
+            console.log('🚀 ~TABS if subBlockToBuild is carousel~ aspectMatches:', aspectMatches);
+            tabContentDiv.classList.add(aspectMatches);
+          }
           const newRow = document.createElement('div');
           newRow.append(tabCategoryDiv);
           newRow.append(tabContentDiv);
@@ -85,6 +116,12 @@ export default async function decorate(block) {
               tabCategoryDiv.innerHTML = oldTabCategory.innerHTML;
               const tabContentDiv = document.createElement('div');
               tabContentDiv.append(subBlock);
+              // check if aspect ratio is present and set aspect ratio class
+              const aspectMatches = getAspectRatioClass(row);
+              if (aspectMatches) {
+                console.log('🚀 ~TABS if isNonStandard ~ aspectMatches:', aspectMatches);
+                tabContentDiv.classList.add(aspectMatches);
+              }
               const newRow = document.createElement('div');
               newRow.append(tabCategoryDiv);
               newRow.append(tabContentDiv);
@@ -119,11 +156,9 @@ export default async function decorate(block) {
             // tabAspectRatioDiv.innerHTML = contentValue.firstElementChild;
             const tabContentDiv = document.createElement('div');
             // check if aspect ratio is present and set aspect ratio class
-            const aspectRatioPresent = row.children[2];
-            const aspectMarker = aspectRatioPresent && [...aspectRatioPresent.classList].find((cls) => cls.startsWith('aspect-'));
-            let aspectMatches = null;
-            if (aspectMarker) {
-              aspectMatches = [...aspectRatioPresent.classList].find((cls) => cls.startsWith('aspect-'));
+            const aspectMatches = getAspectRatioClass(row);
+            if (aspectMatches) {
+              console.log('🚀 ~TABS if isStandard ~ aspectMatches:', aspectMatches);
               tabContentDiv.classList.add(aspectMatches);
             }
             tabContentDiv.append(subBlock);

--- a/aemedge/blocks/tabs/tabs.js
+++ b/aemedge/blocks/tabs/tabs.js
@@ -77,7 +77,7 @@ export default async function decorate(block) {
           // check if aspect ratio is present and set aspect ratio class
           const aspectMatches = getAspectRatioClass(row);
           if (aspectMatches) {
-            console.log('🚀 ~TABS if subBlockToBuild is carousel~ aspectMatches:', aspectMatches);
+            // console.log('🚀 ~TABS if subBlockToBuild is carousel~ aspectMatches:', aspectMatches);
             tabContentDiv.classList.add(aspectMatches);
           }
           const newRow = document.createElement('div');
@@ -119,7 +119,7 @@ export default async function decorate(block) {
               // check if aspect ratio is present and set aspect ratio class
               const aspectMatches = getAspectRatioClass(row);
               if (aspectMatches) {
-                console.log('🚀 ~TABS if isNonStandard ~ aspectMatches:', aspectMatches);
+                // console.log('🚀 ~TABS if isNonStandard ~ aspectMatches:', aspectMatches);
                 tabContentDiv.classList.add(aspectMatches);
               }
               const newRow = document.createElement('div');
@@ -158,7 +158,7 @@ export default async function decorate(block) {
             // check if aspect ratio is present and set aspect ratio class
             const aspectMatches = getAspectRatioClass(row);
             if (aspectMatches) {
-              console.log('🚀 ~TABS if isStandard ~ aspectMatches:', aspectMatches);
+              // console.log('🚀 ~TABS if isStandard ~ aspectMatches:', aspectMatches);
               tabContentDiv.classList.add(aspectMatches);
             }
             tabContentDiv.append(subBlock);

--- a/aemedge/blocks/tabs/tabs.js
+++ b/aemedge/blocks/tabs/tabs.js
@@ -109,27 +109,28 @@ export default async function decorate(block) {
           rows.forEach((row) => {
             const subBlockContent = [];
             const contentKey = row.children[1].innerHTML;
-            console.log('🚀 ~ rows.forEach ~ contentKey:', contentKey);
             const contentValue = row.children[2].innerHTML;
-            console.log('🚀 ~ rows.forEach ~ row.children[2]:', row.children[2]);
-            console.log('🚀 ~ rows.forEach ~ contentValue:', contentValue);
             subBlockContent.push([contentKey, contentValue]);
             // build sub block with the existing content
             const subBlock = buildBlock(subBlockToBuild, subBlockContent);
             // add tabCategory and sub block content to newDiv
             const tabCategoryDiv = document.createElement('div');
             tabCategoryDiv.innerHTML = row.firstElementChild.innerHTML;
-            // const tabAspectRatioDiv = document.createElement('div');
             // tabAspectRatioDiv.innerHTML = contentValue.firstElementChild;
             const tabContentDiv = document.createElement('div');
+            // check if aspect ratio is present and set aspect ratio class
+            const aspectRatioPresent = row.children[2];
+            const aspectMarker = aspectRatioPresent && [...aspectRatioPresent.classList].find((cls) => cls.startsWith('aspect-'));
+            let aspectMatches = null;
+            if (aspectMarker) {
+              aspectMatches = [...aspectRatioPresent.classList].find((cls) => cls.startsWith('aspect-'));
+              tabContentDiv.classList.add(aspectMatches);
+            }
             tabContentDiv.append(subBlock);
             const newRow = document.createElement('div');
             newRow.append(tabCategoryDiv);
-            // newRow.append(tabAspectRatioDiv);
             newRow.append(tabContentDiv);
             newBlock.append(newRow);
-            console.log('🚀 ~ rows.forEach ~ newRow:', newRow);
-            // console.log('🚀 ~ rows.forEach ~ tabAspectRatioDiv:', tabAspectRatioDiv);
           });
         }
       }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -490,7 +490,8 @@ export function extractStyleVariables() {
     const valignRegex = text && /\{valign-([^}]*)\}/; // valign-top, valign-middle, valign-bottom
     const targetRegex = text && /\{target-([^}]*)\}/; // target-blank, target-self
     const idRegex = text && /\{id-([^}]*)\}/; // id-coolsection, etc
-    const colorRegex = text && /\{(?!size-|align-|valign-|spacer-|target-|id-)([a-zA-Z-\s]+)?\}/;
+    const aspectRatioRegex = text && /\{aspect-([^}]*)\}/; // aspect-square, aspect-landscape, aspect-portrait (default)
+    const colorRegex = text && /\{(?!size-|align-|valign-|spacer-|target-|id-|aspect-)([a-zA-Z-\s]+)?\}/;
     const spanRegex = new RegExp(`\\[([\\s\\S]*?)\\]${colorRegex.source}`); // [plain text]{color}
 
     const spacerMatch = text.match(/\{spacer-(\d+)}/); // {spacer-5}
@@ -502,6 +503,8 @@ export function extractStyleVariables() {
     const colorMatches = text.match(colorRegex);
     const targetMatches = text.match(targetRegex);
     const idMatches = text.match(idRegex);
+    const aspectRatioMatches = text.match(aspectRatioRegex);
+
     // case where size, align are to be added to the node
     if (sizeMatches && sizeMatches[1] !== undefined) {
       const size = sizeMatches[1];
@@ -542,6 +545,17 @@ export function extractStyleVariables() {
         if (colorMatches) {
           const backgroundColor = colorMatches[1];
           up.classList.add(`bg-${toClassName(backgroundColor)}`);
+        }
+        // handle aspect ratio in carousels
+        if (aspectRatioMatches && aspectRatioMatches[1] !== undefined) {
+          const aspectRatioMatch = aspectRatioMatches[1];
+          console.log('🚀 ~ aspectRatioMatch:', aspectRatioMatch);
+          up.classList.add(`aspect-${aspectRatioMatch}`);
+          console.log('🚀 ~ up:', up);
+          console.log('🚀 ~ up.classList:', up.classList);
+          // up.innerHTML = up.innerHTML.replace(aspectRatioRegex, '');
+          console.log('🚀 ~ up.innerHTML:', up.innerHTML);
+          console.log('🚀 ~ node.innerHTML:', node.innerHTML);
         }
         node.remove();
       }

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -546,16 +546,10 @@ export function extractStyleVariables() {
           const backgroundColor = colorMatches[1];
           up.classList.add(`bg-${toClassName(backgroundColor)}`);
         }
-        // handle aspect ratio in carousels
+        // pass aspect ratio through in class for styling carousels
         if (aspectRatioMatches && aspectRatioMatches[1] !== undefined) {
           const aspectRatioMatch = aspectRatioMatches[1];
-          console.log('🚀 ~ aspectRatioMatch:', aspectRatioMatch);
           up.classList.add(`aspect-${aspectRatioMatch}`);
-          console.log('🚀 ~ up:', up);
-          console.log('🚀 ~ up.classList:', up.classList);
-          // up.innerHTML = up.innerHTML.replace(aspectRatioRegex, '');
-          console.log('🚀 ~ up.innerHTML:', up.innerHTML);
-          console.log('🚀 ~ node.innerHTML:', node.innerHTML);
         }
         node.remove();
       }


### PR DESCRIPTION
Fix #179 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/channels
- After: https://179-carouselvariants--sling--da-pilot.aem.page/drafts/chelms/channels

Look at the "Movies" and "Add-Ons" tabs of the bottom-most image carousel on the test pages. Movies thumbnail images look bad as they're actually portrait shaped, but being confined to 1:1 aspect ratio. Add-Ons image thumbnails are 16:9 ratio (they were set by height previously, so they look visually the same, but the aspect ratio is actually enforced.

Movies:
![image](https://github.com/user-attachments/assets/b8a98379-bb47-4cef-ba58-31f309d5752d)

Add-Ons:
![image](https://github.com/user-attachments/assets/64b2c8df-0cf2-4fd9-addd-06b931545066)

![image](https://github.com/user-attachments/assets/2a50e110-8c60-4e77-9fdc-0ec74079efce)
