### PR TITLE
Adding CSS for standalone carousel aspect ratio handling

### DIFF
--- a/aemedge/blocks/carousel/carousel.css
+++ b/aemedge/blocks/carousel/carousel.css
@@ -109,7 +109,7 @@
   aspect-ratio: 2 / 3; /* default aspect ratio (portrait) for images in carousel */
 }
 
-
+/* Aspect ratio classes when in tabs */
 .aspect-square .carousel .carousel-slide .carousel-slide-image picture {
   aspect-ratio: 1 / 1;
 }
@@ -119,6 +119,19 @@
 }
 
 .aspect-none .carousel .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: unset;
+}
+
+/* Aspect ratio classes when standalone */
+.carousel.aspect-square .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: 1 / 1;
+}
+
+.carousel.aspect-landscape .carousel-slide .carousel-slide-image picture {
+  aspect-ratio: 16 / 9;
+}
+
+.carousel.aspect-none .carousel-slide .carousel-slide-image picture {
   aspect-ratio: unset;
 }
 

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -506,7 +506,7 @@ export function extractStyleVariables() {
     const valignRegex = text && /\{valign-([^}]*)\}/; // valign-top, valign-middle, valign-bottom
     const targetRegex = text && /\{target-([^}]*)\}/; // target-blank, target-self
     const idRegex = text && /\{id-([^}]*)\}/; // id-coolsection, etc
-    const aspectRatioRegex = text && /\{aspect-([^}]*)\}/; // aspect-square, aspect-landscape, aspect-portrait (default)
+    const aspectRatioRegex = text && /\{aspect-([^}]*)\}/; // aspect-square, aspect-landscape, aspect-none, aspect-portrait (default)
     const colorRegex = text && /\{(?!size-|align-|valign-|spacer-|target-|id-|aspect-)([a-zA-Z-\s]+)?\}/;
     const spanRegex = new RegExp(`\\[([\\s\\S]*?)\\]${colorRegex.source}`); // [plain text]{color}
 


### PR DESCRIPTION
Fix #187 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/library/blocks/carousel
- After: https://187-carousel-standalone--sling--da-pilot.aem.page/library/blocks/carousel
