### PR TITLE
move default header to /aemedge for consistency

### DIFF
--- a/aemedge/blocks/header/header.js
+++ b/aemedge/blocks/header/header.js
@@ -127,7 +127,7 @@ function showsubmenu(nav, backbutton) {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/aemedge/nav';
   const fragment = await loadFragment(navPath);
   // decorate nav DOM
   block.textContent = '';


### PR DESCRIPTION
Copied the /nav to /aemedge/nav for now. 
Once this PR gets merged , will delete the /nav . and only keep the /aemedge/nav to keep it consistent with /aemedge/footer

Fix #68 
Test URLs:
- Before: https://main--sling--da-pilot.aem.live
- After: https://organise--sling--da-pilot.aem.live
