### PR TITLE
center or align-center will work

### DIFF
--- a/aemedge/blocks/banner-image/banner-image.css
+++ b/aemedge/blocks/banner-image/banner-image.css
@@ -27,7 +27,6 @@
     width: 100%;
     -webkit-box-align: start;
     align-items: start;
-    text-align: left;
     position: relative;
     height: 100%;
 

--- a/aemedge/blocks/marquee/marquee.css
+++ b/aemedge/blocks/marquee/marquee.css
@@ -18,7 +18,6 @@
   width: 100%;
   -webkit-box-align: start;
   align-items: start;
-  text-align: left;
   position: relative;
   height: 100%;
   min-height: 426px;

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -402,6 +402,11 @@ picture {
   text-align: center;
     background-position-x: center;
 
+    .banner-content .text-cta-container .buttons-container, 
+    .marquee-content .text-cta-container .buttons-container {
+      width: auto;
+    }
+
     .button-container.combined {
         margin-left: auto !important;
         margin-right: auto !important;


### PR DESCRIPTION
Blocks can be authored with "center" or "align center" styles to make their text and buttons center.

Fix #210 

Test URLs:
Marquee -- look at the turquoise one
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/all-banner-types
- After: https://210-centertext--sling--da-pilot.aem.page/drafts/chelms/all-banner-types

banner-image, look at the blue + orange ones
- Before: https://main--sling--da-pilot.aem.page/drafts/chelms/sectionflex
- After: https://210-centertext--sling--da-pilot.aem.page/drafts/chelms/sectionflex
