### PR TITLE
Fixed table cell spacing

### DIFF
--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -107,7 +107,11 @@
     font-size: var(--body-font-size-xs);
 
     th, td {
-      padding: 0 6px;
+      padding: 10px;
+    }
+
+    td p:last-child, tr p:last-child {
+      margin-bottom: 0;
     }
 
     thead tr {
@@ -118,7 +122,15 @@
   td:not([data-align="right"], [data-align="left"], [data-align="justify"], .align-right, .align-left) {
     text-align: center;
   }
+
+  td:not([data-align="right"], [data-align="left"], [data-align="justify"], .align-right, .align-left):first-child {
+    text-align: left;
+  }
  }
+}
+
+.table-wrapper {
+  margin: 24px auto;
 }
 
 /* Full column-align (left, center, right) styles for up to 6 columns */

--- a/aemedge/blocks/table/table.css
+++ b/aemedge/blocks/table/table.css
@@ -126,6 +126,10 @@
   td:not([data-align="right"], [data-align="left"], [data-align="justify"], .align-right, .align-left):first-child {
     text-align: left;
   }
+
+  th:not([data-align="right"], [data-align="left"], [data-align="justify"], .align-right, .align-left):first-child {
+    text-align: left;
+  }
  }
 }
 


### PR DESCRIPTION
First column is now left aligned (but not header row `th`s, only `td`s) by default. Tables all get 24px top/bottom margin via table-wrapper class. 

Fix #216 

Test URLs:
- Before: https://main--sling--da-pilot.aem.page/library/blocks/table
- After: https://216-tablespacing--sling--da-pilot.aem.page/library/blocks/table

Additional Test URLs:
- Before: https://main--sling--da-pilot.aem.page/sports
- After: https://216-tablespacing--sling--da-pilot.aem.page/sports

Sports page `Select Markets` table also looks better with this fix.
![image](https://github.com/user-attachments/assets/f72f03f0-3b91-47f4-ab52-35bc92947f0a)

